### PR TITLE
Return null for module name when extraction fails

### DIFF
--- a/plexus-java/src/main/java/org/codehaus/plexus/languages/java/jpms/LocationManager.java
+++ b/plexus-java/src/main/java/org/codehaus/plexus/languages/java/jpms/LocationManager.java
@@ -329,7 +329,7 @@ public class LocationManager
         JavaModuleDescriptor moduleDescriptor = null;
         
         // either jar or outputDirectory
-        if ( Files.isRegularFile( path ) && !path.getFileName().toString().endsWith( ".jar" ) )
+        if ( !Files.exists( path ) || ( Files.isRegularFile( path ) && !path.getFileName().toString().endsWith( ".jar" ) ) )
         {
             throw new IllegalArgumentException( "'" +  path.toString() + "' not allowed on the path, only outputDirectories and jars are accepted" );
         }

--- a/plexus-java/src/test/java/org/codehaus/plexus/languages/java/jpms/LocationManagerIT.java
+++ b/plexus-java/src/test/java/org/codehaus/plexus/languages/java/jpms/LocationManagerIT.java
@@ -72,7 +72,7 @@ public class LocationManagerIT
     @Test
     public void testManifestWithoutReflectRequires() throws Exception
     {
-        Path abc = Paths.get( "src/test/resources/manifest.without/out" );
+        Path abc = Paths.get( "src/test/resources/dir.manifest.without/out" );
         JavaModuleDescriptor descriptor = JavaModuleDescriptor.newModule( "base" ).requires( "any" ).build();
         when( qdoxParser.fromSourcePath( any( Path.class ) ) ).thenReturn( descriptor );
         ResolvePathsRequest<Path> request = ResolvePathsRequest.ofPaths( Collections.singletonList( abc ) ).setMainModuleDescriptor( mockModuleInfoJava );
@@ -89,7 +89,7 @@ public class LocationManagerIT
     @Test
     public void testEmptyWithReflectRequires() throws Exception
     {
-        Path abc = Paths.get( "src/test/resources/empty/out" );
+        Path abc = Paths.get( "src/test/resources/dir.empty/out" );
         JavaModuleDescriptor descriptor = JavaModuleDescriptor.newModule( "base" ).requires( "a.b.c" ).build();
         when( qdoxParser.fromSourcePath( any( Path.class ) ) ).thenReturn( descriptor );
         ResolvePathsRequest<Path> request = ResolvePathsRequest.ofPaths( Collections.singletonList( abc ) ).setMainModuleDescriptor( mockModuleInfoJava );
@@ -108,7 +108,7 @@ public class LocationManagerIT
     {
         assumeThat( "Requires at least Java 9", System.getProperty( "java.version" ), not( startsWith( "1." ) ) );
         
-        Path p = Paths.get( "src/test/resources/jar.empty.invalid.name/101-1.0.0-SNAPSHOT.jar" );
+        Path p = Paths.get( "src/test/resources/jar.empty.invalid.name/101-1.0.0-SNAPSHOT-notexisting.jar" );
         ResolvePathRequest<Path> request = ResolvePathRequest.ofPath( p );
         
         locationManager.resolvePath( request );
@@ -124,6 +124,7 @@ public class LocationManagerIT
         
         ResolvePathsResult<Path> result = locationManager.resolvePaths( request );
         
-        assertThat( result.getPathExceptions().size(), is( 1 ) );
+        assertThat( result.getClasspathElements().size(), is( 1 ) );
+        assertThat( result.getPathExceptions().size(), is( 0 ) );
     }
 }


### PR DESCRIPTION
As detailed in https://issues.apache.org/jira/browse/MJAVADOC-609,
module name extraction can easily fail, due to a legacy jar having a
file naming convention that doesn't match what ModuleFinder expects,
when determining an automatic module name from the file name.

This failure to determine the automatic module name should not cause the
jar to be missing from the resulting class path.

This patch handles the FindException that ModuleFinder throws when
looking for module descriptors, and returns null, indicating no name.
This should allow the jar to still be added as a class path element,
even though it can't be added as a module path element. Named modules
won't be able to use the jar from the module path, but automatically
named modules should still be able to use the jar from the UNNAMED
module on the class path.

Also:

* Update LocationManagerIT to test the change
* Make the LocationManager perform strict check for file existence
* Fix broken LocationManagerIT tests (references to non-existent
  test/resource/dir.* directories) revealed by strict file existence
  checks in LocationManager